### PR TITLE
MBC5+RAM+BATTERY 対応

### DIFF
--- a/src/mbc.rs
+++ b/src/mbc.rs
@@ -32,6 +32,7 @@ pub fn new_mbc_reader<'a>(
             | MbcType::Mbc3TimerRamBattery => Box::new(Mbc3Reader::new(board, header)),
             MbcType::Mbc5
             | MbcType::Mbc5Ram
+            | MbcType::Mbc5RamBattery
             | MbcType::Mbc5Rumble
             | MbcType::Mbc5RumbleRam
             | MbcType::Mbc5RumbleRamBattery => Box::new(Mbc5Reader::new(board, header)),


### PR DESCRIPTION
### 変更点

カートリッジタイプのチェック処理の部分に `MbcType::Mbc5RamBattery` を追加しました。

### 確認内容

ROM+MBC5+RAM+Battery カートリッジ (GBC用) を読み出して、FlashGBX/GBxCart RW 1.4aで読み出した結果とチェックサムが一致することを確認しました。

### 確認方法

Raspberry Pi 4 B 対応のために下記のパッチで rppal のバージョンを変更して確認しました:
参考: https://github.com/golemparts/rppal/releases/tag/0.12.0
```diff
diff --git a/Cargo.lock b/Cargo.lock
index b63809a..87590cd 100644
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -245,11 +245,10 @@ checksum = "24d5f089152e60f62d28b835fbff2cd2e8dc0baf1ac13343bef92ab7eed84548"
 
 [[package]]
 name = "rppal"
-version = "0.11.3"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "137dbba1fb867daa27cda4c3cd6a11bca5bb5a1551f034cf9319b994846ddbe1"
+checksum = "612e1a22e21f08a246657c6433fe52b773ae43d07c9ef88ccfc433cc8683caba"
 dependencies = [
- "lazy_static",
  "libc",
 ]
 
diff --git a/Cargo.toml b/Cargo.toml
index 2513359..0435a34 100644
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2018"
 anyhow = "1.0.38"
 num-traits = "0.2"
 num-derive = "0.3"
-rppal = "0.11.3"
+rppal = "0.14.1"
 clap = "3.0.0-beta.2"
 indicatif = "0.15.0"
```

またデータの破損を防ぐためにGBカートリッジに 5V を供給しました:
![2023-06-18-16-52-31](https://github.com/mj-hd/gb-reader/assets/1730234/9765a4b4-f349-464f-b821-9f08357a5965)
